### PR TITLE
update vite to 7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "devDependencies": {
         "tailwindcss": "^4.0.0",
         "@tailwindcss/vite": "^4.1.4",
-        "vite": "^6.3.2"
+        "vite": "^7.0.0"
     },
     "scripts": {
         "dev": "vite build --watch",


### PR DESCRIPTION
Vite 7.0 recently released
https://vite.dev/blog/announcing-vite7

But there are no changes required for our setup since we use so little of what vite offers.

One "main" thing is the fact, that they dropped NodeJS 18 support, but NodeJS 18 [isn't being supported anymore anyways](https://nodejs.org/en/about/previous-releases)