### PR TITLE
Fix text alignment in index template

### DIFF
--- a/templates/plugin/Bake/Template/index.twig
+++ b/templates/plugin/Bake/Template/index.twig
@@ -57,7 +57,7 @@
 {% elseif columnData.type == 'boolean' %}
                     <td class="text-right"><?= h(${{ singularVar }}->{{ field }} ? '✔' : '✖') ?></td>
 {% elseif columnData.type not in ['integer', 'float', 'decimal', 'biginteger', 'smallinteger', 'tinyinteger'] %}
-                    <td class="text-right"><?= h(${{ singularVar }}->{{ field }}) ?></td>
+                    <td class="text-left"><?= h(${{ singularVar }}->{{ field }}) ?></td>
 {% elseif columnData.null %}
                     <td class="text-right"><?= ${{ singularVar }}->{{ field }} === null ? '' : $this->Number->format(${{ singularVar }}->{{ field }}) ?></td>
 {% else %}


### PR DESCRIPTION
I don't think right aligned text should be the default for columns like `title` or `slug`. I missed this when authoring the templates earlier.